### PR TITLE
Change layout algorithm from planar to spring in plot_causal_graph

### DIFF
--- a/causadb/plotting.py
+++ b/causadb/plotting.py
@@ -19,7 +19,7 @@ def plot_causal_graph(model: "Model") -> None:
     ```
     """
     G = nx.DiGraph(model.get_edges())
-    pos = nx.layout.planar_layout(G)
+    pos = nx.layout.spring_layout(G)
     nx.draw(
         G,
         pos=pos,


### PR DESCRIPTION
This commit changes the layout algorithm used in the `plot_causal_graph` function from `planar_layout` to `spring_layout`. Generally I find this is easier on the eye for DAGs. Just a suggestion!